### PR TITLE
update-pv-pvc

### DIFF
--- a/dev/helm/templates/pv.yaml
+++ b/dev/helm/templates/pv.yaml
@@ -1,17 +1,17 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: snapshot-manual-volume-backup
+  name: snapshot-backup-playbook-pvc-3538782b-b73c-11ea-b41a-06d20c3955ba
 spec:
   accessModes:
   - ReadWriteOnce
   awsElasticBlockStore:
-    volumeID: vol-0bf0245ce79dda5d1
+    volumeID: vol-0580029db6e624a72
   capacity:
     storage: 10Gi
   claimRef:
     apiVersion: v1
     kind: PersistentVolumeClaim
-    name: snapshot-manual-volume-backup
+    name: snapshot-backup-playbook-pvc-3538782b-b73c-11ea-b41a-06d20c3955ba
     namespace: playbook-v2-staging
-    storageClassName: aws-snapshot
+    storageClassName: ebs-sc

--- a/dev/helm/templates/pv.yaml
+++ b/dev/helm/templates/pv.yaml
@@ -1,16 +1,16 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: snapshot-backup-playbook-pvc-3538782b-b73c-11ea-b41a-06d20c3955ba
+  name: playbook-snap-1-22-23
 spec:
   accessModes:
   - ReadWriteOnce
   awsElasticBlockStore:
-    volumeID: vol-0132fcccc454ff97d
+    volumeID: vol-019e466c6ac4063ab
   capacity:
     storage: 10Gi
   claimRef:
     apiVersion: v1
     kind: PersistentVolumeClaim
-    name: snapshot-backup-playbook-pvc-3538782b-b73c-11ea-b41a-06d20c3955ba
+    name: playbook-snap-1-22-23
     namespace: playbook-v2-staging

--- a/dev/helm/templates/pv.yaml
+++ b/dev/helm/templates/pv.yaml
@@ -14,4 +14,3 @@ spec:
     kind: PersistentVolumeClaim
     name: snapshot-backup-playbook-pvc-3538782b-b73c-11ea-b41a-06d20c3955ba
     namespace: playbook-v2-staging
-    storageClassName: ebs

--- a/dev/helm/templates/pv.yaml
+++ b/dev/helm/templates/pv.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: snapshot-manual-volume-backup
+spec:
+  accessModes:
+  - ReadWriteOnce
+  awsElasticBlockStore:
+    volumeID: vol-0bf0245ce79dda5d1
+  capacity:
+    storage: 10Gi
+  claimRef:
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    name: snapshot-manual-volume-backup
+    namespace: playbook-v2-staging
+    storageClassName: aws-snapshot

--- a/dev/helm/templates/pv.yaml
+++ b/dev/helm/templates/pv.yaml
@@ -14,4 +14,4 @@ spec:
     kind: PersistentVolumeClaim
     name: snapshot-backup-playbook-pvc-3538782b-b73c-11ea-b41a-06d20c3955ba
     namespace: playbook-v2-staging
-    storageClassName: ebs-sc
+    storageClassName: ebs

--- a/dev/helm/templates/pv.yaml
+++ b/dev/helm/templates/pv.yaml
@@ -6,7 +6,7 @@ spec:
   accessModes:
   - ReadWriteOnce
   awsElasticBlockStore:
-    volumeID: vol-0580029db6e624a72
+    volumeID: vol-0132fcccc454ff97d
   capacity:
     storage: 10Gi
   claimRef:

--- a/dev/helm/templates/volume-from-snap.yaml
+++ b/dev/helm/templates/volume-from-snap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: snapshot-manual-volume-backup
+  name: snapshot-backup-playbook-pvc-3538782b-b73c-11ea-b41a-06d20c3955ba
   namespace: playbook-v2-staging
   labels:
     app: {{ template "wiki.fullname" . }}

--- a/dev/helm/templates/volume-from-snap.yaml
+++ b/dev/helm/templates/volume-from-snap.yaml
@@ -10,7 +10,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
     component: config
 spec:
-  storageClassName: ebs
+  storageClassName: ebs-sc
   dataSource:
     name: snapshot-backup-playbook-pvc-3538782b-b73c-11ea-b41a-06d20c3955ba
     kind: VolumeSnapshot

--- a/dev/helm/templates/volume-from-snap.yaml
+++ b/dev/helm/templates/volume-from-snap.yaml
@@ -1,14 +1,10 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: snapshot-backup-playbook-pvc-3538782b-b73c-11ea-b41a-06d20c3955ba
+  name: playbook-snap-1-22-23
   namespace: playbook-v2-staging
 spec:
-  storageClassName: ebs-sc
-  dataSource:
-    name: snapshot-backup-playbook-pvc-3538782b-b73c-11ea-b41a-06d20c3955ba
-    kind: VolumeSnapshot
-    apiGroup: snapshot.storage.k8s.io
+  storageClassName: ebs
   accessModes:
   - ReadWriteOnce
   resources:

--- a/dev/helm/templates/volume-from-snap.yaml
+++ b/dev/helm/templates/volume-from-snap.yaml
@@ -10,9 +10,9 @@ metadata:
     heritage: "{{ .Release.Service }}"
     component: config
 spec:
-  storageClassName: ebs-sc
+  storageClassName: ebs
   dataSource:
-    name: test-snapshot
+    name: snapshot-backup-playbook-pvc-3538782b-b73c-11ea-b41a-06d20c3955ba
     kind: VolumeSnapshot
     apiGroup: snapshot.storage.k8s.io
   accessModes:

--- a/dev/helm/templates/volume-from-snap.yaml
+++ b/dev/helm/templates/volume-from-snap.yaml
@@ -1,8 +1,8 @@
-
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ template "wiki.fullname" . }}-volume
+  name: snapshot-manual-volume-backup
+  namespace: playbook-v2-staging
   labels:
     app: {{ template "wiki.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -10,6 +10,11 @@ metadata:
     heritage: "{{ .Release.Service }}"
     component: config
 spec:
+  storageClassName: ebs-sc
+  dataSource:
+    name: test-snapshot
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
   accessModes:
   - ReadWriteOnce
   resources:

--- a/dev/helm/templates/volume-from-snap.yaml
+++ b/dev/helm/templates/volume-from-snap.yaml
@@ -3,12 +3,6 @@ kind: PersistentVolumeClaim
 metadata:
   name: snapshot-backup-playbook-pvc-3538782b-b73c-11ea-b41a-06d20c3955ba
   namespace: playbook-v2-staging
-  labels:
-    app: {{ template "wiki.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
-    component: config
 spec:
   storageClassName: ebs-sc
   dataSource:

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -72,7 +72,7 @@ postgresql:
     enabled: false
   persistence:
     enabled: true
-    storageClass: ebs
+    storageClass: ebs-sc
 
 extraEnvVars:
   - name: DB_TYPE

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -72,7 +72,7 @@ postgresql:
     enabled: false
   persistence:
     enabled: true
-    storageClass: aws-snapshot
+    storageClass: ebs-sc
 
 extraEnvVars:
   - name: DB_TYPE

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -72,7 +72,7 @@ postgresql:
     enabled: false
   persistence:
     enabled: true
-    storageClass: ebs-sc
+    storageClass: ebs
 
 extraEnvVars:
   - name: DB_TYPE

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -72,7 +72,7 @@ postgresql:
     enabled: false
   persistence:
     enabled: true
-    storageClass: ebs
+    storageClass: aws-snapshot
 
 extraEnvVars:
   - name: DB_TYPE


### PR DESCRIPTION
Updating the PV and PVC to include the specific volume ID from a volume created from a snapshot backup from the original playbook staging instance.

I am trying to provision the pv form the pvc in the helm deploy.